### PR TITLE
feat: update application port from 3000 to 4000 in Docker configuration

### DIFF
--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   app:
     build: .
     ports:
-      - "3000:3000"
+      - "4000:4000"
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/appdb
     depends_on:

--- a/server/dockerfile
+++ b/server/dockerfile
@@ -11,6 +11,6 @@ RUN bun install
 COPY . .
 RUN bunx prisma generate
 
-EXPOSE 3000
+EXPOSE 4000
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This pull request includes changes to the `server/docker-compose.yaml` and `server/dockerfile` to update the port configuration for the application. The most important changes are:

Port configuration updates:

* [`server/docker-compose.yaml`](diffhunk://#diff-d668d5bb435135514a4183a8d6250affe45f72cbf18642b5e54f4e125be0b8bdL5-R5): Changed the app service port mapping from `3000:3000` to `4000:4000` to reflect the new port configuration.
* [`server/dockerfile`](diffhunk://#diff-5a04fe8c4ceb47a4dd207977bce5223b4a1e81935f079eea09be62c95165c31fL14-R14): Updated the exposed port from `3000` to `4000` to match the new port configuration.